### PR TITLE
TL-283 

### DIFF
--- a/src/main/java/edu/colorado/cires/cmg/tracklinegen/BaseRowListener.java
+++ b/src/main/java/edu/colorado/cires/cmg/tracklinegen/BaseRowListener.java
@@ -436,13 +436,19 @@ public class BaseRowListener<T extends DataRow> implements RowListener<T> {
   private boolean shouldSplit(PointState point1, PointState point2) {
     if (point2.isSimplified()) {
       return point2.getIndex() == 0;
-    } if (isSplittingByMsEnabled() || isSplittingByNmEnabled()) {
+
+    }
+    if (isSplittingByMsEnabled()) {
       double difference = point2.getPoint().getCoordinate().getZ() - point1.getPoint().getCoordinate().getZ();
+      if (difference > msSplit) {
+        return true;
+      }
+    }
+    if (isSplittingByNmEnabled()) {
       // Calculate distance between two points by retrieving distance in meters and converting to nautical miles
       double distance = (getDistance(point1.getPoint().getCoordinate(), point2.getPoint().getCoordinate()) / 1852);
-      return (difference > msSplit) || (distance > NmSplit);
+      return distance > NmSplit;
     }
-
     return false;
   }
 

--- a/src/main/java/edu/colorado/cires/cmg/tracklinegen/BaseRowListener.java
+++ b/src/main/java/edu/colorado/cires/cmg/tracklinegen/BaseRowListener.java
@@ -19,7 +19,7 @@ import org.locationtech.jts.geom.Point;
 
 public class BaseRowListener<T extends DataRow> implements RowListener<T> {
 
-  private final long NmSplit;
+  private final long nmSplit;
   private final long msSplit;
   private final GeometrySimplifier geometrySimplifier;
   private final Predicate<T> filterRow;
@@ -41,7 +41,6 @@ public class BaseRowListener<T extends DataRow> implements RowListener<T> {
 
   /**
    *
-   * @param NmSplit Nautical miles value by which to split trackline segments
    * @param msSplit
    * @param geometrySimplifier
    * @param lineWriter
@@ -55,7 +54,6 @@ public class BaseRowListener<T extends DataRow> implements RowListener<T> {
    */
   @Deprecated
   public BaseRowListener(
-      long NmSplit,
       long msSplit,
       GeometrySimplifier geometrySimplifier,
       GeoJsonMultiLineWriter lineWriter,
@@ -65,11 +63,11 @@ public class BaseRowListener<T extends DataRow> implements RowListener<T> {
       GeometryFactory geometryFactory,
       int geoJsonPrecision
   ) {
-    this(NmSplit, msSplit, geometrySimplifier, lineWriter, batchSize, filterRow, maxAllowedSimplifiedPoints, geometryFactory, geoJsonPrecision, 0D);
+    this(msSplit, geometrySimplifier, lineWriter, batchSize, filterRow, maxAllowedSimplifiedPoints, geometryFactory, geoJsonPrecision, 0D);
   }
 
+  @Deprecated
   public BaseRowListener(
-      long NmSplit,
       long msSplit,
       GeometrySimplifier geometrySimplifier,
       GeoJsonMultiLineWriter lineWriter,
@@ -80,8 +78,7 @@ public class BaseRowListener<T extends DataRow> implements RowListener<T> {
       int geoJsonPrecision,
       double maxAllowedSpeedKnts
   ) {
-
-    this.NmSplit = NmSplit;
+    this(BaseRowListenerConfiguration<T>)
     this.msSplit = msSplit;
     this.geometrySimplifier = geometrySimplifier;
     this.lineWriter = lineWriter;
@@ -96,6 +93,26 @@ public class BaseRowListener<T extends DataRow> implements RowListener<T> {
     }
     format = new DecimalFormat(sb.toString(), DecimalFormatSymbols.getInstance(Locale.ENGLISH));
     this.maxAllowedSpeedKnts = maxAllowedSpeedKnts;
+  }
+
+  public BaseRowListener(
+      BaseRowListenerConfiguration<T> config  )
+  {
+    this.nmSplit = config.getNmSplit();
+    this.msSplit = config.getMsSplit();
+    this.geometrySimplifier = config.getGeometrySimplifier();
+    this.lineWriter = config.getLineWriter();
+    this.filterRow = config.getFilterRow();
+    this.batchSize = config.getBatchSize();
+    this.maxAllowedSimplifiedPoints = config.getMaxAllowedSimplifiedPoints();
+    this.geometryFactory = config.getGeometryFactory();
+    this.minDistance = 1d / Math.pow(10d, config.getGeoJsonPrecision());
+    StringBuilder sb = new StringBuilder("0.");
+    for (int i = 1; i <= config.getGeoJsonPrecision(); i++) {
+      sb.append("#");
+    }
+    format = new DecimalFormat(sb.toString(), DecimalFormatSymbols.getInstance(Locale.ENGLISH));
+    this.maxAllowedSpeedKnts = config.getMaxAllowedSpeedKnts();
   }
 
   @Override

--- a/src/main/java/edu/colorado/cires/cmg/tracklinegen/BaseRowListener.java
+++ b/src/main/java/edu/colorado/cires/cmg/tracklinegen/BaseRowListener.java
@@ -19,7 +19,7 @@ import org.locationtech.jts.geom.Point;
 
 public class BaseRowListener<T extends DataRow> implements RowListener<T> {
 
-  private final long distanceSplit;
+  private final long NmSplit;
   private final long msSplit;
   private final GeometrySimplifier geometrySimplifier;
   private final Predicate<T> filterRow;
@@ -41,7 +41,7 @@ public class BaseRowListener<T extends DataRow> implements RowListener<T> {
 
   /**
    *
-   * @param distanceSplit
+   * @param NmSplit Nautical miles value by which to split trackline segments
    * @param msSplit
    * @param geometrySimplifier
    * @param lineWriter
@@ -55,7 +55,7 @@ public class BaseRowListener<T extends DataRow> implements RowListener<T> {
    */
   @Deprecated
   public BaseRowListener(
-      long distanceSplit,
+      long NmSplit,
       long msSplit,
       GeometrySimplifier geometrySimplifier,
       GeoJsonMultiLineWriter lineWriter,
@@ -65,11 +65,11 @@ public class BaseRowListener<T extends DataRow> implements RowListener<T> {
       GeometryFactory geometryFactory,
       int geoJsonPrecision
   ) {
-    this(distanceSplit, msSplit, geometrySimplifier, lineWriter, batchSize, filterRow, maxAllowedSimplifiedPoints, geometryFactory, geoJsonPrecision, 0D);
+    this(NmSplit, msSplit, geometrySimplifier, lineWriter, batchSize, filterRow, maxAllowedSimplifiedPoints, geometryFactory, geoJsonPrecision, 0D);
   }
 
   public BaseRowListener(
-      long distanceSplit,
+      long NmSplit,
       long msSplit,
       GeometrySimplifier geometrySimplifier,
       GeoJsonMultiLineWriter lineWriter,
@@ -81,7 +81,7 @@ public class BaseRowListener<T extends DataRow> implements RowListener<T> {
       double maxAllowedSpeedKnts
   ) {
 
-    this.distanceSplit = distanceSplit;
+    this.NmSplit = NmSplit;
     this.msSplit = msSplit;
     this.geometrySimplifier = geometrySimplifier;
     this.lineWriter = lineWriter;
@@ -436,11 +436,11 @@ public class BaseRowListener<T extends DataRow> implements RowListener<T> {
   private boolean shouldSplit(PointState point1, PointState point2) {
     if (point2.isSimplified()) {
       return point2.getIndex() == 0;
-    } if (isSplittingByMsEnabled() || isSplittingByDistanceEnabled()) {
+    } if (isSplittingByMsEnabled() || isSplittingByNmEnabled()) {
       double difference = point2.getPoint().getCoordinate().getZ() - point1.getPoint().getCoordinate().getZ();
       // Calculate distance between two points by retrieving distance in meters and converting to nautical miles
       double distance = (getDistance(point1.getPoint().getCoordinate(), point2.getPoint().getCoordinate()) / 1852);
-      return (difference > msSplit) || (distance > distanceSplit);
+      return (difference > msSplit) || (distance > NmSplit);
     }
 
     return false;
@@ -450,8 +450,8 @@ public class BaseRowListener<T extends DataRow> implements RowListener<T> {
     return msSplit > 0;
   }
 
-  private boolean isSplittingByDistanceEnabled() {
-    return distanceSplit > 0;
+  private boolean isSplittingByNmEnabled() {
+    return NmSplit > 0;
   }
 
 

--- a/src/main/java/edu/colorado/cires/cmg/tracklinegen/BaseRowListenerConfiguration.java
+++ b/src/main/java/edu/colorado/cires/cmg/tracklinegen/BaseRowListenerConfiguration.java
@@ -1,0 +1,177 @@
+package edu.colorado.cires.cmg.tracklinegen;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+import java.util.function.Predicate;
+import org.locationtech.jts.geom.GeometryFactory;
+
+public class BaseRowListenerConfiguration<T> {
+
+  private final long nmSplit;
+  private final long msSplit;
+  private final GeometrySimplifier geometrySimplifier;
+  private final Predicate<T> filterRow;
+  private final GeoJsonMultiLineWriter lineWriter;
+  private final int batchSize;
+  private final long maxAllowedSimplifiedPoints;
+  private final double maxAllowedSpeedKnts;
+  private final GeometryFactory geometryFactory;
+  private final int geoJsonPrecision;
+
+  private BaseRowListenerConfiguration(Builder<T> builder) {
+
+    nmSplit = builder.nmSplit;
+    msSplit = builder.msSplit;
+    geometrySimplifier = builder.geometrySimplifier;
+    filterRow = builder.filterRow;
+    lineWriter = builder.lineWriter;
+    batchSize = builder.batchSize;
+    maxAllowedSimplifiedPoints = builder.maxAllowedSimplifiedPoints;
+    maxAllowedSpeedKnts = builder.maxAllowedSpeedKnts;
+    geometryFactory = builder.geometryFactory;
+    geoJsonPrecision = builder.geoJsonPrecision;
+
+  }
+
+  public Long getNmSplit() {
+    return nmSplit;
+  }
+
+  public Long getMsSplit() {
+    return msSplit;
+  }
+
+  public GeometrySimplifier getGeometrySimplifier() {
+    return geometrySimplifier;
+  }
+
+  public Predicate<T> getFilterRow() {
+    return filterRow;
+  }
+
+  public GeoJsonMultiLineWriter getLineWriter() {
+    return lineWriter;
+  }
+
+  public Integer getBatchSize() {
+    return batchSize;
+  }
+
+  public Long getMaxAllowedSimplifiedPoints() {
+    return maxAllowedSimplifiedPoints;
+  }
+
+  public Double getMaxAllowedSpeedKnts() {
+    return maxAllowedSpeedKnts;
+  }
+
+  public GeometryFactory getGeometryFactory() {
+    return geometryFactory;
+  }
+
+  public Integer getGeoJsonPrecision() {
+    return geoJsonPrecision;
+  }
+
+  public static<T> Builder<T> configure() {
+    return new Builder<>();
+  }
+
+  public static<T> Builder<T> configure(
+      BaseRowListenerConfiguration<T> properties) {
+    return new Builder<>(properties);
+  }
+
+  public static class Builder<T> {
+
+    private Long nmSplit;
+    private Long msSplit;
+    private GeometrySimplifier geometrySimplifier;
+    private Predicate<T> filterRow;
+    private GeoJsonMultiLineWriter lineWriter;
+    private Integer batchSize;
+    private Long maxAllowedSimplifiedPoints;
+    private Double maxAllowedSpeedKnts;
+    private GeometryFactory geometryFactory;
+    private Double minDistance;
+    private DecimalFormat format;
+    private Integer geoJsonPrecision;
+
+
+    public Builder() {
+
+    }
+
+    private Builder(BaseRowListenerConfiguration<T> properties) {
+      nmSplit = properties.nmSplit;
+      msSplit = properties.msSplit;
+      geometrySimplifier = properties.geometrySimplifier;
+      filterRow = properties.filterRow;
+      lineWriter = properties.lineWriter;
+      batchSize = properties.batchSize;
+      maxAllowedSimplifiedPoints = properties.maxAllowedSimplifiedPoints;
+      maxAllowedSpeedKnts = properties.maxAllowedSpeedKnts;
+      geometryFactory = properties.geometryFactory;
+      geoJsonPrecision = properties.geoJsonPrecision;
+    }
+
+    public Builder<T> withNmSplit(Long nmSplit) {
+      this.nmSplit = nmSplit;
+      return this;
+    }
+
+    public Builder<T> withMsSplit(Long msSplit) {
+      this.msSplit = msSplit;
+      return this;
+    }
+
+    public Builder<T> withGeometrySimplifier(GeometrySimplifier geometrySimplifier) {
+      this.geometrySimplifier = geometrySimplifier;
+      return this;
+    }
+
+    public Builder<T> withFilterRow(Predicate<T> filterRow) {
+      this.filterRow = filterRow;
+      return this;
+    }
+
+    public Builder<T> withLineWriter(GeoJsonMultiLineWriter lineWriter) {
+      this.lineWriter = lineWriter;
+      return this;
+    }
+
+    public Builder<T> withBatchSize(Integer batchSize) {
+      this.batchSize = batchSize;
+
+      return this;
+    }
+
+    public Builder<T> withMaxAllowedSimplifiedPoints(Long maxAllowedSimplifiedPoints) {
+      this.maxAllowedSimplifiedPoints = maxAllowedSimplifiedPoints;
+
+      return this;
+    }
+
+    public Builder<T> withMaxAllowedSpeedKnts(Double maxAllowedSpeedKnts) {
+      this.maxAllowedSpeedKnts = maxAllowedSpeedKnts;
+      return this;
+    }
+
+    public Builder<T> withGeometryFactory(GeometryFactory geometryFactory) {
+      this.geometryFactory = geometryFactory;
+      return this;
+    }
+
+    public Builder<T> withGeoJsonPrecision(int geoJsonPrecision) {
+      this.geoJsonPrecision = geoJsonPrecision;
+      return this;
+    }
+
+    public BaseRowListenerConfiguration<T> build() {
+      return new BaseRowListenerConfiguration<>(this);
+    }
+  }
+}
+
+

--- a/src/main/java/edu/colorado/cires/cmg/tracklinegen/BaseRowListenerConfiguration.java
+++ b/src/main/java/edu/colorado/cires/cmg/tracklinegen/BaseRowListenerConfiguration.java
@@ -1,12 +1,9 @@
 package edu.colorado.cires.cmg.tracklinegen;
 
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.util.Locale;
 import java.util.function.Predicate;
 import org.locationtech.jts.geom.GeometryFactory;
 
-public class BaseRowListenerConfiguration<T> {
+public class BaseRowListenerConfiguration<T extends DataRow> {
 
   private final long nmSplit;
   private final long msSplit;
@@ -34,11 +31,11 @@ public class BaseRowListenerConfiguration<T> {
 
   }
 
-  public Long getNmSplit() {
+  public long getNmSplit() {
     return nmSplit;
   }
 
-  public Long getMsSplit() {
+  public long getMsSplit() {
     return msSplit;
   }
 
@@ -54,15 +51,15 @@ public class BaseRowListenerConfiguration<T> {
     return lineWriter;
   }
 
-  public Integer getBatchSize() {
+  public int getBatchSize() {
     return batchSize;
   }
 
-  public Long getMaxAllowedSimplifiedPoints() {
+  public long getMaxAllowedSimplifiedPoints() {
     return maxAllowedSimplifiedPoints;
   }
 
-  public Double getMaxAllowedSpeedKnts() {
+  public double getMaxAllowedSpeedKnts() {
     return maxAllowedSpeedKnts;
   }
 
@@ -70,36 +67,32 @@ public class BaseRowListenerConfiguration<T> {
     return geometryFactory;
   }
 
-  public Integer getGeoJsonPrecision() {
+  public int getGeoJsonPrecision() {
     return geoJsonPrecision;
   }
 
-  public static<T> Builder<T> configure() {
+  public static <T extends DataRow> Builder<T> configure() {
     return new Builder<>();
   }
 
-  public static<T> Builder<T> configure(
-      BaseRowListenerConfiguration<T> properties) {
+  public static <T extends DataRow> Builder<T> configure(BaseRowListenerConfiguration<T> properties) {
     return new Builder<>(properties);
   }
 
-  public static class Builder<T> {
+  public static class Builder<T extends DataRow> {
 
-    private Long nmSplit;
-    private Long msSplit;
+    private long nmSplit;
+    private long msSplit;
     private GeometrySimplifier geometrySimplifier;
     private Predicate<T> filterRow;
     private GeoJsonMultiLineWriter lineWriter;
-    private Integer batchSize;
-    private Long maxAllowedSimplifiedPoints;
-    private Double maxAllowedSpeedKnts;
+    private int batchSize;
+    private long maxAllowedSimplifiedPoints;
+    private double maxAllowedSpeedKnts;
     private GeometryFactory geometryFactory;
-    private Double minDistance;
-    private DecimalFormat format;
-    private Integer geoJsonPrecision;
+    private int geoJsonPrecision;
 
-
-    public Builder() {
+    private Builder() {
 
     }
 

--- a/src/test/java/edu/colorado/cires/cmg/tracklinegen/geometrySimplifier/GeoSimplifierProcessor.java
+++ b/src/test/java/edu/colorado/cires/cmg/tracklinegen/geometrySimplifier/GeoSimplifierProcessor.java
@@ -13,6 +13,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 
 public class GeoSimplifierProcessor extends TracklineProcessor<GeoSimplifierContext, DataRow, GsBaseRowListener> {
   private int geoJsonPrecision = 5;
+  private long distanceSplit;
   private long msSplit;
   private GeometrySimplifier geometrySimplifier;
   private int simplifierBatchSize;
@@ -24,10 +25,11 @@ public class GeoSimplifierProcessor extends TracklineProcessor<GeoSimplifierCont
   private final Predicate<GeoDataRow> rowFilter;
   private final double maxAllowedSpeedKnts;
 
-  public GeoSimplifierProcessor(int geoJsonPrecision, long msSplit, GeometrySimplifier geometrySimplifier, int simplifierBatchSize,
+  public GeoSimplifierProcessor(int geoJsonPrecision, long distanceSplit, long msSplit, GeometrySimplifier geometrySimplifier, int simplifierBatchSize,
       Path fnvFile, ObjectMapper objectMapper, Path gsf, long maxCount, GeometryFactory geometryFactory,
       Predicate<GeoDataRow> rowFilter, double maxAllowedSpeedKnts) {
     this.geoJsonPrecision = geoJsonPrecision;
+    this.distanceSplit = distanceSplit;
     this.msSplit = msSplit;
     this.geometrySimplifier = geometrySimplifier;
     this.simplifierBatchSize = simplifierBatchSize;
@@ -48,6 +50,7 @@ public class GeoSimplifierProcessor extends TracklineProcessor<GeoSimplifierCont
   @Override
   protected List<GsBaseRowListener> createRowListeners(GeoSimplifierContext context) {
     return Collections.singletonList(new GsBaseRowListener(
+        distanceSplit,
         msSplit,
         geometrySimplifier,
         context.getLineWriter(),

--- a/src/test/java/edu/colorado/cires/cmg/tracklinegen/geometrySimplifier/GeoSimplifierProcessor.java
+++ b/src/test/java/edu/colorado/cires/cmg/tracklinegen/geometrySimplifier/GeoSimplifierProcessor.java
@@ -13,7 +13,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 
 public class GeoSimplifierProcessor extends TracklineProcessor<GeoSimplifierContext, DataRow, GsBaseRowListener> {
   private int geoJsonPrecision = 5;
-  private long distanceSplit;
+  private long NmSplit;
   private long msSplit;
   private GeometrySimplifier geometrySimplifier;
   private int simplifierBatchSize;
@@ -25,11 +25,11 @@ public class GeoSimplifierProcessor extends TracklineProcessor<GeoSimplifierCont
   private final Predicate<GeoDataRow> rowFilter;
   private final double maxAllowedSpeedKnts;
 
-  public GeoSimplifierProcessor(int geoJsonPrecision, long distanceSplit, long msSplit, GeometrySimplifier geometrySimplifier, int simplifierBatchSize,
+  public GeoSimplifierProcessor(int geoJsonPrecision, long NmSplit, long msSplit, GeometrySimplifier geometrySimplifier, int simplifierBatchSize,
       Path fnvFile, ObjectMapper objectMapper, Path gsf, long maxCount, GeometryFactory geometryFactory,
       Predicate<GeoDataRow> rowFilter, double maxAllowedSpeedKnts) {
     this.geoJsonPrecision = geoJsonPrecision;
-    this.distanceSplit = distanceSplit;
+    this.NmSplit = NmSplit;
     this.msSplit = msSplit;
     this.geometrySimplifier = geometrySimplifier;
     this.simplifierBatchSize = simplifierBatchSize;
@@ -50,7 +50,7 @@ public class GeoSimplifierProcessor extends TracklineProcessor<GeoSimplifierCont
   @Override
   protected List<GsBaseRowListener> createRowListeners(GeoSimplifierContext context) {
     return Collections.singletonList(new GsBaseRowListener(
-        distanceSplit,
+        NmSplit,
         msSplit,
         geometrySimplifier,
         context.getLineWriter(),

--- a/src/test/java/edu/colorado/cires/cmg/tracklinegen/geometrySimplifier/GsBaseRowListener.java
+++ b/src/test/java/edu/colorado/cires/cmg/tracklinegen/geometrySimplifier/GsBaseRowListener.java
@@ -1,6 +1,7 @@
 package edu.colorado.cires.cmg.tracklinegen.geometrySimplifier;
 
 import edu.colorado.cires.cmg.tracklinegen.BaseRowListener;
+import edu.colorado.cires.cmg.tracklinegen.BaseRowListenerConfiguration;
 import edu.colorado.cires.cmg.tracklinegen.GeoJsonMultiLineWriter;
 import edu.colorado.cires.cmg.tracklinegen.GeometrySimplifier;
 import java.util.function.Predicate;
@@ -8,18 +9,21 @@ import org.locationtech.jts.geom.GeometryFactory;
 
 public class GsBaseRowListener extends BaseRowListener<GeoDataRow> {
 
-  public GsBaseRowListener(long NmSplit, long msSplit, GeometrySimplifier geometrySimplifier,
+  public GsBaseRowListener(long nmSplit, long msSplit, GeometrySimplifier geometrySimplifier,
       GeoJsonMultiLineWriter lineWriter, int batchSize, long maxCount,
       GeometryFactory geometryFactory, int geoJsonPrecision, Predicate<GeoDataRow> rowFilter, double maxAllowedSpeedKnts) {
-    super(NmSplit,
-        msSplit,
-        geometrySimplifier,
-        lineWriter,
-        batchSize,
-        rowFilter,
-        maxCount,
-        geometryFactory,
-        geoJsonPrecision,
-       maxAllowedSpeedKnts);
+
+    super(BaseRowListenerConfiguration.<GeoDataRow>configure()
+        .withNmSplit(nmSplit)
+        .withMsSplit(msSplit)
+        .withGeometrySimplifier(geometrySimplifier)
+        .withLineWriter(lineWriter)
+        .withBatchSize(batchSize)
+        .withFilterRow(rowFilter)
+        .withMaxAllowedSimplifiedPoints(maxCount)
+        .withGeometryFactory(geometryFactory)
+        .withGeoJsonPrecision(geoJsonPrecision)
+        .withMaxAllowedSpeedKnts(maxAllowedSpeedKnts)
+        .build());
   }
 }

--- a/src/test/java/edu/colorado/cires/cmg/tracklinegen/geometrySimplifier/GsBaseRowListener.java
+++ b/src/test/java/edu/colorado/cires/cmg/tracklinegen/geometrySimplifier/GsBaseRowListener.java
@@ -8,10 +8,10 @@ import org.locationtech.jts.geom.GeometryFactory;
 
 public class GsBaseRowListener extends BaseRowListener<GeoDataRow> {
 
-  public GsBaseRowListener(long distanceSplit, long msSplit, GeometrySimplifier geometrySimplifier,
+  public GsBaseRowListener(long NmSplit, long msSplit, GeometrySimplifier geometrySimplifier,
       GeoJsonMultiLineWriter lineWriter, int batchSize, long maxCount,
       GeometryFactory geometryFactory, int geoJsonPrecision, Predicate<GeoDataRow> rowFilter, double maxAllowedSpeedKnts) {
-    super(distanceSplit,
+    super(NmSplit,
         msSplit,
         geometrySimplifier,
         lineWriter,

--- a/src/test/java/edu/colorado/cires/cmg/tracklinegen/geometrySimplifier/GsBaseRowListener.java
+++ b/src/test/java/edu/colorado/cires/cmg/tracklinegen/geometrySimplifier/GsBaseRowListener.java
@@ -8,10 +8,11 @@ import org.locationtech.jts.geom.GeometryFactory;
 
 public class GsBaseRowListener extends BaseRowListener<GeoDataRow> {
 
-  public GsBaseRowListener(long msSplit, GeometrySimplifier geometrySimplifier,
+  public GsBaseRowListener(long distanceSplit, long msSplit, GeometrySimplifier geometrySimplifier,
       GeoJsonMultiLineWriter lineWriter, int batchSize, long maxCount,
       GeometryFactory geometryFactory, int geoJsonPrecision, Predicate<GeoDataRow> rowFilter, double maxAllowedSpeedKnts) {
-    super(msSplit,
+    super(distanceSplit,
+        msSplit,
         geometrySimplifier,
         lineWriter,
         batchSize,

--- a/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/BathRowListenerTest.java
+++ b/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/BathRowListenerTest.java
@@ -33,7 +33,7 @@ public class BathRowListenerTest {
   public void testEmpty() throws Exception {
     List<GeoDataRow> rows = Collections.emptyList();
 
-    final long NmSplit = 2000L;
+    final long NmSplit = 0;
     final long msSplit = 1000L * 2L;
     final int batchSize = 5000;
 
@@ -95,7 +95,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(1.4).withTimestamp(start.plusSeconds(12)).build()
     );
 
-    final long NmSplit = 2000L;
+    final long NmSplit = 0;
     final long msSplit = 1000L * 2L;
     final int batchSize = 5000;
 
@@ -146,7 +146,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(0.9).withTimestamp(start.plusSeconds(4)).build()
     );
 
-    final long NmSplit = 2000L;
+    final long NmSplit = 0;
     final long msSplit = 1000L * 2L;
     final int batchSize = 5000;
 
@@ -209,7 +209,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(10D).withBathyTime(1.0).withTimestamp(start.plusSeconds(10)).build()
     );
 
-    final long NmSplit = 2000L;
+    final long NmSplit = 0;
     final long msSplit = 1000L * 2L;
     final int batchSize = 6;
 
@@ -285,7 +285,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(15D).withBathyTime(1.0).withTimestamp(start.plusSeconds(15)).build()
 
     );
-    final long NmSplit = 2000L;
+    final long NmSplit = 0;
     final long msSplit = 1000L * 2L;
     final int batchSize = 3;
 
@@ -364,7 +364,7 @@ public class BathRowListenerTest {
 
     );
 
-    final long NmSplit = 2000L;
+    final long NmSplit = 0;
     final long msSplit = 1000L * 2L;
     final int batchSize = 3;
 
@@ -434,7 +434,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(12D).withBathyTime(1.0).withTimestamp(start.plusSeconds(12)).build()
 
     );
-    final long NmSplit = 2000L;
+    final long NmSplit = 0;
     final long msSplit = 1000L * 2L;
     final int batchSize = 3;
 
@@ -502,7 +502,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(11D).withBathyTime(1.0).withTimestamp(start.plusSeconds(11)).build()
 
     );
-    final long NmSplit = 2000L;
+    final long NmSplit = 0;
     final long msSplit = 1000L * 2L;
     final int batchSize = 3;
 
@@ -549,7 +549,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(1D).withLon(2D).withBathyTime(1.0).withTimestamp(start.plusSeconds(2)).build()
     );
 
-    final long NmSplit = 2000L;
+    final long NmSplit = 0;
     final long msSplit = 10;
     final int batchSize = 100;
 
@@ -611,7 +611,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(1.4).withBathyQualityCode(6).withTimestamp(start.plusSeconds(12)).build()
     );
 
-    final long NmSplit = 2000L;
+    final long NmSplit = 0;
     final long msSplit = 1000L * 2L;
     final int batchSize = 5000;
 

--- a/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/BathRowListenerTest.java
+++ b/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/BathRowListenerTest.java
@@ -33,6 +33,7 @@ public class BathRowListenerTest {
   public void testEmpty() throws Exception {
     List<GeoDataRow> rows = Collections.emptyList();
 
+    final long distanceSplit = 2000L;
     final long msSplit = 1000L * 2L;
     final int batchSize = 5000;
 
@@ -40,6 +41,7 @@ public class BathRowListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
+          distanceSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -93,6 +95,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(1.4).withTimestamp(start.plusSeconds(12)).build()
     );
 
+    final long distanceSplit = 2000L;
     final long msSplit = 1000L * 2L;
     final int batchSize = 5000;
 
@@ -100,6 +103,7 @@ public class BathRowListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
+          distanceSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -142,6 +146,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(0.9).withTimestamp(start.plusSeconds(4)).build()
     );
 
+    final long distanceSplit = 2000L;
     final long msSplit = 1000L * 2L;
     final int batchSize = 5000;
 
@@ -149,6 +154,7 @@ public class BathRowListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
+          distanceSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -203,6 +209,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(10D).withBathyTime(1.0).withTimestamp(start.plusSeconds(10)).build()
     );
 
+    final long distanceSplit = 2000L;
     final long msSplit = 1000L * 2L;
     final int batchSize = 6;
 
@@ -210,6 +217,7 @@ public class BathRowListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
+          distanceSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -277,7 +285,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(15D).withBathyTime(1.0).withTimestamp(start.plusSeconds(15)).build()
 
     );
-
+    final long distanceSplit = 2000L;
     final long msSplit = 1000L * 2L;
     final int batchSize = 3;
 
@@ -285,6 +293,7 @@ public class BathRowListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
+          distanceSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -355,6 +364,7 @@ public class BathRowListenerTest {
 
     );
 
+    final long distanceSplit = 2000L;
     final long msSplit = 1000L * 2L;
     final int batchSize = 3;
 
@@ -362,6 +372,7 @@ public class BathRowListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
+          distanceSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -423,7 +434,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(12D).withBathyTime(1.0).withTimestamp(start.plusSeconds(12)).build()
 
     );
-
+    final long distanceSplit = 2000L;
     final long msSplit = 1000L * 2L;
     final int batchSize = 3;
 
@@ -431,6 +442,7 @@ public class BathRowListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
+          distanceSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -490,7 +502,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(11D).withBathyTime(1.0).withTimestamp(start.plusSeconds(11)).build()
 
     );
-
+    final long distanceSplit = 2000L;
     final long msSplit = 1000L * 2L;
     final int batchSize = 3;
 
@@ -498,6 +510,7 @@ public class BathRowListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
+          distanceSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -536,6 +549,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(1D).withLon(2D).withBathyTime(1.0).withTimestamp(start.plusSeconds(2)).build()
     );
 
+    final long distanceSplit = 2000L;
     final long msSplit = 10;
     final int batchSize = 100;
 
@@ -543,6 +557,7 @@ public class BathRowListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
+          distanceSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -596,6 +611,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(1.4).withBathyQualityCode(6).withTimestamp(start.plusSeconds(12)).build()
     );
 
+    final long distanceSplit = 2000L;
     final long msSplit = 1000L * 2L;
     final int batchSize = 5000;
 
@@ -603,6 +619,7 @@ public class BathRowListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
+          distanceSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,

--- a/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/BathRowListenerTest.java
+++ b/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/BathRowListenerTest.java
@@ -33,7 +33,7 @@ public class BathRowListenerTest {
   public void testEmpty() throws Exception {
     List<GeoDataRow> rows = Collections.emptyList();
 
-    final long distanceSplit = 2000L;
+    final long NmSplit = 2000L;
     final long msSplit = 1000L * 2L;
     final int batchSize = 5000;
 
@@ -41,7 +41,7 @@ public class BathRowListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
-          distanceSplit,
+          NmSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -95,7 +95,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(1.4).withTimestamp(start.plusSeconds(12)).build()
     );
 
-    final long distanceSplit = 2000L;
+    final long NmSplit = 2000L;
     final long msSplit = 1000L * 2L;
     final int batchSize = 5000;
 
@@ -103,7 +103,7 @@ public class BathRowListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
-          distanceSplit,
+          NmSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -146,7 +146,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(0.9).withTimestamp(start.plusSeconds(4)).build()
     );
 
-    final long distanceSplit = 2000L;
+    final long NmSplit = 2000L;
     final long msSplit = 1000L * 2L;
     final int batchSize = 5000;
 
@@ -154,7 +154,7 @@ public class BathRowListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
-          distanceSplit,
+          NmSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -209,7 +209,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(10D).withBathyTime(1.0).withTimestamp(start.plusSeconds(10)).build()
     );
 
-    final long distanceSplit = 2000L;
+    final long NmSplit = 2000L;
     final long msSplit = 1000L * 2L;
     final int batchSize = 6;
 
@@ -217,7 +217,7 @@ public class BathRowListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
-          distanceSplit,
+          NmSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -285,7 +285,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(15D).withBathyTime(1.0).withTimestamp(start.plusSeconds(15)).build()
 
     );
-    final long distanceSplit = 2000L;
+    final long NmSplit = 2000L;
     final long msSplit = 1000L * 2L;
     final int batchSize = 3;
 
@@ -293,7 +293,7 @@ public class BathRowListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
-          distanceSplit,
+          NmSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -364,7 +364,7 @@ public class BathRowListenerTest {
 
     );
 
-    final long distanceSplit = 2000L;
+    final long NmSplit = 2000L;
     final long msSplit = 1000L * 2L;
     final int batchSize = 3;
 
@@ -372,7 +372,7 @@ public class BathRowListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
-          distanceSplit,
+          NmSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -434,7 +434,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(12D).withBathyTime(1.0).withTimestamp(start.plusSeconds(12)).build()
 
     );
-    final long distanceSplit = 2000L;
+    final long NmSplit = 2000L;
     final long msSplit = 1000L * 2L;
     final int batchSize = 3;
 
@@ -442,7 +442,7 @@ public class BathRowListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
-          distanceSplit,
+          NmSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -502,7 +502,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(11D).withBathyTime(1.0).withTimestamp(start.plusSeconds(11)).build()
 
     );
-    final long distanceSplit = 2000L;
+    final long NmSplit = 2000L;
     final long msSplit = 1000L * 2L;
     final int batchSize = 3;
 
@@ -510,7 +510,7 @@ public class BathRowListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
-          distanceSplit,
+          NmSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -549,7 +549,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(1D).withLon(2D).withBathyTime(1.0).withTimestamp(start.plusSeconds(2)).build()
     );
 
-    final long distanceSplit = 2000L;
+    final long NmSplit = 2000L;
     final long msSplit = 10;
     final int batchSize = 100;
 
@@ -557,7 +557,7 @@ public class BathRowListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
-          distanceSplit,
+          NmSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -611,7 +611,7 @@ public class BathRowListenerTest {
 //        DataRow.Builder.configure().withLat(0D).withLon(1.4).withBathyQualityCode(6).withTimestamp(start.plusSeconds(12)).build()
     );
 
-    final long distanceSplit = 2000L;
+    final long NmSplit = 2000L;
     final long msSplit = 1000L * 2L;
     final int batchSize = 5000;
 
@@ -619,7 +619,7 @@ public class BathRowListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
-          distanceSplit,
+          NmSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,

--- a/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/FnvSplittingTest.java
+++ b/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/FnvSplittingTest.java
@@ -205,7 +205,7 @@ public class FnvSplittingTest {
 //    Instant timestamp = LocalDateTime.parse(tokens[0], DATE_FORMAT).toInstant(ZoneOffset.UTC);
       return new FnvDataRow(timestamp, Double.parseDouble(tokens[2]), Double.parseDouble(tokens[3]));
     };
-    private final long distanceSplit;
+    private final long NmSplit;
     private final long msSplit;
     private final GeometrySimplifier geometrySimplifier;
     private final int batchSize;
@@ -215,9 +215,9 @@ public class FnvSplittingTest {
     private final OutputStream out;
     private final GeometryFactory geometryFactory;
 
-    public FnvTracklineProcessor(long distanceSplit, long msSplit, GeometrySimplifier geometrySimplifier, int batchSize, List<Path> fnvFiles, int precision,
+    public FnvTracklineProcessor(long NmSplit, long msSplit, GeometrySimplifier geometrySimplifier, int batchSize, List<Path> fnvFiles, int precision,
         ObjectMapper objectMapper, OutputStream out, GeometryFactory geometryFactory) {
-      this.distanceSplit = distanceSplit;
+      this.NmSplit = NmSplit;
       this.msSplit = msSplit;
       this.geometrySimplifier = geometrySimplifier;
       this.batchSize = batchSize;
@@ -236,7 +236,7 @@ public class FnvSplittingTest {
     @Override
     protected List<FnvRowListener> createRowListeners(FnvTracklineContext context) {
       return Collections.singletonList(
-          new FnvRowListener(distanceSplit, msSplit, geometrySimplifier, context.getLineWriter(), batchSize, geometryFactory, precision, maxAllowedSpeedKnts));
+          new FnvRowListener(NmSplit, msSplit, geometrySimplifier, context.getLineWriter(), batchSize, geometryFactory, precision, maxAllowedSpeedKnts));
     }
 
     @Override
@@ -286,9 +286,9 @@ public class FnvSplittingTest {
 
   private static class FnvRowListener extends BaseRowListener<FnvDataRow> {
 
-    public FnvRowListener(long distanceSplit, long msSplit, GeometrySimplifier geometrySimplifier, GeoJsonMultiLineWriter lineWriter, int batchSize,
+    public FnvRowListener(long NmSplit, long msSplit, GeometrySimplifier geometrySimplifier, GeoJsonMultiLineWriter lineWriter, int batchSize,
         GeometryFactory geometryFactory, int precision, double maxAllowedSpeedKnts) {
-      super(distanceSplit, msSplit, geometrySimplifier, lineWriter, batchSize, x -> true, 0, geometryFactory, precision, maxAllowedSpeedKnts);
+      super(NmSplit, msSplit, geometrySimplifier, lineWriter, batchSize, x -> true, 0, geometryFactory, precision, maxAllowedSpeedKnts);
     }
   }
 

--- a/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/FnvSplittingTest.java
+++ b/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/FnvSplittingTest.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import edu.colorado.cires.cmg.iostream.Pipe;
 import edu.colorado.cires.cmg.tracklinegen.BaseRowListener;
+import edu.colorado.cires.cmg.tracklinegen.BaseRowListenerConfiguration;
 import edu.colorado.cires.cmg.tracklinegen.DataRow;
 import edu.colorado.cires.cmg.tracklinegen.GeoJsonMultiLineProcessor;
 import edu.colorado.cires.cmg.tracklinegen.GeoJsonMultiLineWriter;
@@ -286,9 +287,19 @@ public class FnvSplittingTest {
 
   private static class FnvRowListener extends BaseRowListener<FnvDataRow> {
 
-    public FnvRowListener(long NmSplit, long msSplit, GeometrySimplifier geometrySimplifier, GeoJsonMultiLineWriter lineWriter, int batchSize,
+    public FnvRowListener(long nmSplit, long msSplit, GeometrySimplifier geometrySimplifier, GeoJsonMultiLineWriter lineWriter, int batchSize,
         GeometryFactory geometryFactory, int precision, double maxAllowedSpeedKnts) {
-      super(NmSplit, msSplit, geometrySimplifier, lineWriter, batchSize, x -> true, 0, geometryFactory, precision, maxAllowedSpeedKnts);
+      super(BaseRowListenerConfiguration.<FnvDataRow>configure()
+          .withNmSplit(nmSplit)
+          .withMsSplit(msSplit)
+          .withGeometrySimplifier(geometrySimplifier)
+          .withLineWriter(lineWriter)
+          .withBatchSize(batchSize)
+          .withFilterRow(x -> true)
+          .withGeometryFactory(geometryFactory)
+          .withGeoJsonPrecision(precision)
+          .withMaxAllowedSpeedKnts(maxAllowedSpeedKnts)
+          .build());
     }
   }
 

--- a/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/NullDatetimeListenerTest.java
+++ b/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/NullDatetimeListenerTest.java
@@ -19,52 +19,182 @@ import org.locationtech.jts.geom.PrecisionModel;
 
 public class NullDatetimeListenerTest {
 
-    private final int maxCount = 0;
-    private final int geoJsonPrecision = 4;
-    private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
-    final double tol = 0.0001;
-    private final GeometrySimplifier geometrySimplifier = new GeometrySimplifier(tol);
-    private final ObjectMapper objectMapper = new ObjectMapper();
-    private double maxAllowedSpeedKnts = 0D;
+  private final long distanceSplit = 20;
+  private final int maxCount = 0;
+  private final int geoJsonPrecision = 4;
+  private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+  final double tol = 0.0001;
+  private final GeometrySimplifier geometrySimplifier = new GeometrySimplifier(tol);
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private double maxAllowedSpeedKnts = 0D;
 
-    @Test
-    public void testNullDatetime() throws Exception {
-        List<GeoDataRow> rows = Arrays.asList(
-                new GeoDataRow(null,-157.88034, 21.31367),
-                new GeoDataRow(null,-157.89551, 21.3075),
-                new GeoDataRow(null,-157.89037, 21.30076),
-                new GeoDataRow(null,-157.89187, 21.27442)
+  @Test
+  public void testNullDatetime() throws Exception {
+    List<GeoDataRow> rows = Arrays.asList(
+        new GeoDataRow(null, -157.88034, 21.31367),
+        new GeoDataRow(null, -157.89551, 21.3075),
+        new GeoDataRow(null, -157.89037, 21.30076),
+        new GeoDataRow(null, -157.89187, 21.27442)
+    );
+
+    final long msSplit = 1000L * 2L;
+    final int batchSize = 5000;
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
+      GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
+      GsBaseRowListener listener = new GsBaseRowListener(
+          distanceSplit,
+          msSplit,
+          geometrySimplifier,
+          lineWriter,
+          batchSize,
+          maxCount,
+          geometryFactory,
+          geoJsonPrecision,
+          dataRow -> true,
+          maxAllowedSpeedKnts
+      );
+      listener.start();
+      rows.forEach(listener::processRow);
+      listener.finish();
+    }
+    JsonNode expected;
+    try (InputStream in = getClass().getClassLoader().getResourceAsStream("null-datetime.json")) {
+      expected = objectMapper.readTree(in);
+    }
+
+    JsonNode geoJson = objectMapper.readTree(out.toByteArray());
+
+    assertEquals(expected, geoJson);
+
+  }
+
+  @Test
+  public void testSplitNullDatetime() throws Exception {
+    List<GeoDataRow> rows = Arrays.asList(
+        new GeoDataRow(null, -157.88034, 21.31367),
+        new GeoDataRow(null, -157.89551, 21.3075),
+        new GeoDataRow(null, -157.89037, 21.30076),
+        new GeoDataRow(null, -157.89187, 21.27442),
+        new GeoDataRow(null, 167.37895, -15.34297),
+        new GeoDataRow(null, 167.52778, -15.26825)
         );
 
-        final long msSplit = 1000L * 2L;
-        final int batchSize = 5000;
+    final long msSplit = 1000L * 2L;
+    final int batchSize = 5000;
 
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
-            GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
-            GsBaseRowListener listener = new GsBaseRowListener(
-                    msSplit,
-                    geometrySimplifier,
-                    lineWriter,
-                    batchSize,
-                    maxCount,
-                    geometryFactory,
-                    geoJsonPrecision,
-                    dataRow -> true,
-                    maxAllowedSpeedKnts
-            );
-            listener.start();
-            rows.forEach(listener::processRow);
-            listener.finish();
-        }
-        JsonNode expected;
-        try (InputStream in = getClass().getClassLoader().getResourceAsStream("null-datetime.json")) {
-            expected = objectMapper.readTree(in);
-        }
-
-        JsonNode geoJson = objectMapper.readTree(out.toByteArray());
-
-        assertEquals(expected, geoJson);
-
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
+      GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
+      GsBaseRowListener listener = new GsBaseRowListener(
+          distanceSplit,
+          msSplit,
+          geometrySimplifier,
+          lineWriter,
+          batchSize,
+          maxCount,
+          geometryFactory,
+          geoJsonPrecision,
+          dataRow -> true,
+          maxAllowedSpeedKnts
+      );
+      listener.start();
+      rows.forEach(listener::processRow);
+      listener.finish();
     }
+    JsonNode expected;
+    try (InputStream in = getClass().getClassLoader().getResourceAsStream("split-null-datetime.json")) {
+      expected = objectMapper.readTree(in);
+    }
+
+    JsonNode geoJson = objectMapper.readTree(out.toByteArray());
+
+    assertEquals(expected, geoJson);
+
+  }
+
+  @Test
+  public void testSplitNullDatetimeJustOver() throws Exception {
+    List<GeoDataRow> rows = Arrays.asList(
+        new GeoDataRow(null, -157.88034, 21.31367),
+        new GeoDataRow(null, -157.89037, 21.30076),
+        new GeoDataRow(null, -157.89187, 20.91442),
+        new GeoDataRow(null, -157.89187, 20.90442)
+        );
+
+    final long msSplit = 1000L * 2L;
+    final int batchSize = 5000;
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
+      GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
+      GsBaseRowListener listener = new GsBaseRowListener(
+          distanceSplit,
+          msSplit,
+          geometrySimplifier,
+          lineWriter,
+          batchSize,
+          maxCount,
+          geometryFactory,
+          geoJsonPrecision,
+          dataRow -> true,
+          maxAllowedSpeedKnts
+      );
+      listener.start();
+      rows.forEach(listener::processRow);
+      listener.finish();
+    }
+    JsonNode expected;
+    try (InputStream in = getClass().getClassLoader().getResourceAsStream("split-null-datetime-just-over-distance.json")) {
+      expected = objectMapper.readTree(in);
+    }
+
+    JsonNode geoJson = objectMapper.readTree(out.toByteArray());
+
+    assertEquals(expected, geoJson);
+
+  }
+
+  @Test
+  public void testSplitNullDatetimeJustUnder() throws Exception {
+    List<GeoDataRow> rows = Arrays.asList(
+        new GeoDataRow(null, -157.88034, 21.31367),
+        new GeoDataRow(null, -157.89037, 21.30076),
+        new GeoDataRow(null, -157.89187, 21.00021),
+        new GeoDataRow(null, -157.89187, 21.30076)
+    );
+
+    final long msSplit = 1000L * 2L;
+    final int batchSize = 5000;
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
+      GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
+      GsBaseRowListener listener = new GsBaseRowListener(
+          distanceSplit,
+          msSplit,
+          geometrySimplifier,
+          lineWriter,
+          batchSize,
+          maxCount,
+          geometryFactory,
+          geoJsonPrecision,
+          dataRow -> true,
+          maxAllowedSpeedKnts
+      );
+      listener.start();
+      rows.forEach(listener::processRow);
+      listener.finish();
+    }
+    JsonNode expected;
+    try (InputStream in = getClass().getClassLoader().getResourceAsStream("split-null-datetime-just-under-distance.json")) {
+      expected = objectMapper.readTree(in);
+    }
+
+    JsonNode geoJson = objectMapper.readTree(out.toByteArray());
+
+    assertEquals(expected, geoJson);
+
+  }
 }

--- a/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/NullDatetimeListenerTest.java
+++ b/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/NullDatetimeListenerTest.java
@@ -19,7 +19,6 @@ import org.locationtech.jts.geom.PrecisionModel;
 
 public class NullDatetimeListenerTest {
 
-  private final long distanceSplit = 20;
   private final int maxCount = 0;
   private final int geoJsonPrecision = 4;
   private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
@@ -37,6 +36,7 @@ public class NullDatetimeListenerTest {
         new GeoDataRow(null, -157.89187, 21.27442)
     );
 
+    final long NmSplit = 20;
     final long msSplit = 1000L * 2L;
     final int batchSize = 5000;
 
@@ -44,7 +44,7 @@ public class NullDatetimeListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
-          distanceSplit,
+          NmSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -81,6 +81,7 @@ public class NullDatetimeListenerTest {
         new GeoDataRow(null, 167.52778, -15.26825)
         );
 
+    final long NmSplit = 20;
     final long msSplit = 1000L * 2L;
     final int batchSize = 5000;
 
@@ -88,7 +89,7 @@ public class NullDatetimeListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
-          distanceSplit,
+          NmSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -123,6 +124,7 @@ public class NullDatetimeListenerTest {
         new GeoDataRow(null, -157.89187, 20.90442)
         );
 
+    final long NmSplit = 20;
     final long msSplit = 1000L * 2L;
     final int batchSize = 5000;
 
@@ -130,7 +132,7 @@ public class NullDatetimeListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
-          distanceSplit,
+          NmSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,
@@ -165,6 +167,7 @@ public class NullDatetimeListenerTest {
         new GeoDataRow(null, -157.89187, 21.30076)
     );
 
+    final long NmSplit = 20;
     final long msSplit = 1000L * 2L;
     final int batchSize = 5000;
 
@@ -172,7 +175,7 @@ public class NullDatetimeListenerTest {
     try (JsonGenerator jsonGenerator = objectMapper.getFactory().createGenerator(out)) {
       GeoJsonMultiLineWriter lineWriter = new GeoJsonMultiLineWriter(jsonGenerator, geoJsonPrecision);
       GsBaseRowListener listener = new GsBaseRowListener(
-          distanceSplit,
+          NmSplit,
           msSplit,
           geometrySimplifier,
           lineWriter,

--- a/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/PointTest.java
+++ b/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/PointTest.java
@@ -145,6 +145,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
+    final int distanceSplit = 20;
     final int msSplit = 3600000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -159,7 +160,7 @@ public class PointTest {
     byte[] wktBytes = null;
 
     GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-        geoJsonPrecision, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+        geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
         row -> true, maxAllowedSpeedKnts);
     phase1.process();
 
@@ -189,6 +190,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
+    final int distanceSplit = 20;
     final int msSplit = 3600000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -203,7 +205,7 @@ public class PointTest {
     byte[] wktBytes = null;
 
     GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-        geoJsonPrecision, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+        geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
         row -> true, maxAllowedSpeedKnts);
     phase1.process();
 
@@ -233,6 +235,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.00001;
     final int simplifierBatchSize = 3;
+    final int distanceSplit = 20;
     final int msSplit = 10000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -247,7 +250,7 @@ public class PointTest {
     byte[] wktBytes = null;
 
     GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-        geoJsonPrecision, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+        geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
         row -> true, maxAllowedSpeedKnts);
     phase1.process();
 
@@ -275,6 +278,7 @@ public class PointTest {
     for (int simplifierBatchSize = 2; simplifierBatchSize <= 13; simplifierBatchSize++) {
       final int geoJsonPrecision = 5;
       final double simplificationTolerance = 0.000001;
+      final int distanceSplit = 20;
       final int msSplit = 100000;
       final long maxCount = 10000;
       GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -289,7 +293,7 @@ public class PointTest {
       byte[] wktBytes = null;
 
       GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-          geoJsonPrecision, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+          geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
           row -> true, maxAllowedSpeedKnts);
       phase1.process();
 
@@ -317,6 +321,7 @@ public class PointTest {
     for (int simplifierBatchSize = 2; simplifierBatchSize <= 13; simplifierBatchSize++) {
       final int geoJsonPrecision = 5;
       final double simplificationTolerance = 0.01;
+      final int distanceSplit = 20;
       final int msSplit = 100000;
       final long maxCount = 10000;
       GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -331,7 +336,7 @@ public class PointTest {
       byte[] wktBytes = null;
 
       GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-          geoJsonPrecision, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+          geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
           row -> true, maxAllowedSpeedKnts);
       phase1.process();
 
@@ -369,6 +374,7 @@ public class PointTest {
     for (int simplifierBatchSize = 2; simplifierBatchSize <= 13; simplifierBatchSize++) {
       final int geoJsonPrecision = 5;
       final double simplificationTolerance = 0.000001;
+      final int distanceSplit = 100000;
       final int msSplit = 100000;
       final long maxCount = 10000;
       GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -383,7 +389,7 @@ public class PointTest {
       byte[] wktBytes = null;
 
       GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-          geoJsonPrecision, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+          geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
           row -> true, maxAllowedSpeedKnts);
       phase1.process();
 
@@ -409,6 +415,7 @@ public class PointTest {
     for (int simplifierBatchSize = 2; simplifierBatchSize <= 13; simplifierBatchSize++) {
       final int geoJsonPrecision = 5;
       final double simplificationTolerance = 0.000001;
+      final int distanceSplit = 20;
       final int msSplit = 100000;
       final long maxCount = 10000;
       GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -423,7 +430,7 @@ public class PointTest {
       byte[] wktBytes = null;
 
       GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-          geoJsonPrecision, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+          geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
           row -> true, maxAllowedSpeedKnts);
       phase1.process();
 
@@ -449,6 +456,7 @@ public class PointTest {
     for (int simplifierBatchSize = 2; simplifierBatchSize <= 13; simplifierBatchSize++) {
       final int geoJsonPrecision = 5;
       final double simplificationTolerance = 0.000001;
+      final int distanceSplit = 100000;
       final int msSplit = 100000;
       final long maxCount = 10000;
       GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -463,7 +471,7 @@ public class PointTest {
       byte[] wktBytes = null;
 
       GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-          geoJsonPrecision, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+          geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
           row -> true, maxAllowedSpeedKnts);
       phase1.process();
 
@@ -488,6 +496,7 @@ public class PointTest {
   @Test
   public void testLargeFileMultiPrecision() throws Exception {
 
+    final int distanceSplit = 0;
     final int msSplit = 0;
     final long maxCount = 10000;
     final long simplifierBatchSize = maxCount;
@@ -508,7 +517,7 @@ public class PointTest {
     byte[] wktBytes = null;
 
     GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-        geoJsonPrecision, msSplit, geometrySimplifier, (int) simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+        geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, (int) simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
         row -> true, maxAllowedSpeedKnts);
     phase1.process();
 
@@ -535,6 +544,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
+    final int distanceSplit = 20;
     final int msSplit = 3600000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -549,7 +559,7 @@ public class PointTest {
     byte[] wktBytes = null;
 
     GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-        geoJsonPrecision, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+        geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
         row -> true, maxAllowedSpeedKnts);
     phase1.process();
 
@@ -579,6 +589,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
+    final int distanceSplit = 20;
     final int msSplit = 3600000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -593,7 +604,7 @@ public class PointTest {
     byte[] wktBytes = null;
 
     GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-        geoJsonPrecision, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+        geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
         row -> true, maxAllowedSpeedKnts);
     phase1.process();
 
@@ -622,6 +633,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
+    final int distanceSplit = 20;
     final int msSplit = 3600000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -636,7 +648,7 @@ public class PointTest {
     byte[] wktBytes = null;
 
     GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-        geoJsonPrecision, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+        geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
         row -> true, maxAllowedSpeedKnts);
     phase1.process();
 
@@ -665,6 +677,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
+    final int distanceSplit = 20;
     final int msSplit = 3600000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -679,7 +692,7 @@ public class PointTest {
     byte[] wktBytes = null;
 
     GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-        geoJsonPrecision, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+        geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
         row -> false, maxAllowedSpeedKnts);
     phase1.process();
 

--- a/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/PointTest.java
+++ b/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/PointTest.java
@@ -145,7 +145,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
-    final int NmSplit = 20;
+    final int NmSplit = 0;
     final int msSplit = 3600000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -190,7 +190,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
-    final int NmSplit = 20;
+    final int NmSplit = 0;
     final int msSplit = 3600000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -235,7 +235,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.00001;
     final int simplifierBatchSize = 3;
-    final int NmSplit = 20;
+    final int NmSplit = 0;
     final int msSplit = 10000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -278,7 +278,7 @@ public class PointTest {
     for (int simplifierBatchSize = 2; simplifierBatchSize <= 13; simplifierBatchSize++) {
       final int geoJsonPrecision = 5;
       final double simplificationTolerance = 0.000001;
-      final int NmSplit = 20;
+      final int NmSplit = 0;
       final int msSplit = 100000;
       final long maxCount = 10000;
       GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -321,7 +321,7 @@ public class PointTest {
     for (int simplifierBatchSize = 2; simplifierBatchSize <= 13; simplifierBatchSize++) {
       final int geoJsonPrecision = 5;
       final double simplificationTolerance = 0.01;
-      final int NmSplit = 20;
+      final int NmSplit = 0;
       final int msSplit = 100000;
       final long maxCount = 10000;
       GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -374,7 +374,7 @@ public class PointTest {
     for (int simplifierBatchSize = 2; simplifierBatchSize <= 13; simplifierBatchSize++) {
       final int geoJsonPrecision = 5;
       final double simplificationTolerance = 0.000001;
-      final int NmSplit = 100000;
+      final int NmSplit = 0;
       final int msSplit = 100000;
       final long maxCount = 10000;
       GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -415,7 +415,7 @@ public class PointTest {
     for (int simplifierBatchSize = 2; simplifierBatchSize <= 13; simplifierBatchSize++) {
       final int geoJsonPrecision = 5;
       final double simplificationTolerance = 0.000001;
-      final int NmSplit = 20;
+      final int NmSplit = 0;
       final int msSplit = 100000;
       final long maxCount = 10000;
       GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -456,7 +456,7 @@ public class PointTest {
     for (int simplifierBatchSize = 2; simplifierBatchSize <= 13; simplifierBatchSize++) {
       final int geoJsonPrecision = 5;
       final double simplificationTolerance = 0.000001;
-      final int NmSplit = 100000;
+      final int NmSplit = 0;
       final int msSplit = 100000;
       final long maxCount = 10000;
       GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -544,7 +544,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
-    final int NmSplit = 20;
+    final int NmSplit = 0;
     final int msSplit = 3600000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -589,7 +589,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
-    final int NmSplit = 20;
+    final int NmSplit = 0;
     final int msSplit = 3600000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -633,7 +633,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
-    final int NmSplit = 20;
+    final int NmSplit = 0;
     final int msSplit = 3600000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -677,7 +677,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
-    final int NmSplit = 20;
+    final int NmSplit = 0;
     final int msSplit = 3600000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);

--- a/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/PointTest.java
+++ b/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/PointTest.java
@@ -145,7 +145,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
-    final int distanceSplit = 20;
+    final int NmSplit = 20;
     final int msSplit = 3600000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -160,7 +160,7 @@ public class PointTest {
     byte[] wktBytes = null;
 
     GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-        geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+        geoJsonPrecision, NmSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
         row -> true, maxAllowedSpeedKnts);
     phase1.process();
 
@@ -190,7 +190,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
-    final int distanceSplit = 20;
+    final int NmSplit = 20;
     final int msSplit = 3600000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -205,7 +205,7 @@ public class PointTest {
     byte[] wktBytes = null;
 
     GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-        geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+        geoJsonPrecision, NmSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
         row -> true, maxAllowedSpeedKnts);
     phase1.process();
 
@@ -235,7 +235,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.00001;
     final int simplifierBatchSize = 3;
-    final int distanceSplit = 20;
+    final int NmSplit = 20;
     final int msSplit = 10000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -250,7 +250,7 @@ public class PointTest {
     byte[] wktBytes = null;
 
     GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-        geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+        geoJsonPrecision, NmSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
         row -> true, maxAllowedSpeedKnts);
     phase1.process();
 
@@ -278,7 +278,7 @@ public class PointTest {
     for (int simplifierBatchSize = 2; simplifierBatchSize <= 13; simplifierBatchSize++) {
       final int geoJsonPrecision = 5;
       final double simplificationTolerance = 0.000001;
-      final int distanceSplit = 20;
+      final int NmSplit = 20;
       final int msSplit = 100000;
       final long maxCount = 10000;
       GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -293,7 +293,7 @@ public class PointTest {
       byte[] wktBytes = null;
 
       GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-          geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+          geoJsonPrecision, NmSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
           row -> true, maxAllowedSpeedKnts);
       phase1.process();
 
@@ -321,7 +321,7 @@ public class PointTest {
     for (int simplifierBatchSize = 2; simplifierBatchSize <= 13; simplifierBatchSize++) {
       final int geoJsonPrecision = 5;
       final double simplificationTolerance = 0.01;
-      final int distanceSplit = 20;
+      final int NmSplit = 20;
       final int msSplit = 100000;
       final long maxCount = 10000;
       GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -336,7 +336,7 @@ public class PointTest {
       byte[] wktBytes = null;
 
       GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-          geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+          geoJsonPrecision, NmSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
           row -> true, maxAllowedSpeedKnts);
       phase1.process();
 
@@ -374,7 +374,7 @@ public class PointTest {
     for (int simplifierBatchSize = 2; simplifierBatchSize <= 13; simplifierBatchSize++) {
       final int geoJsonPrecision = 5;
       final double simplificationTolerance = 0.000001;
-      final int distanceSplit = 100000;
+      final int NmSplit = 100000;
       final int msSplit = 100000;
       final long maxCount = 10000;
       GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -389,7 +389,7 @@ public class PointTest {
       byte[] wktBytes = null;
 
       GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-          geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+          geoJsonPrecision, NmSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
           row -> true, maxAllowedSpeedKnts);
       phase1.process();
 
@@ -415,7 +415,7 @@ public class PointTest {
     for (int simplifierBatchSize = 2; simplifierBatchSize <= 13; simplifierBatchSize++) {
       final int geoJsonPrecision = 5;
       final double simplificationTolerance = 0.000001;
-      final int distanceSplit = 20;
+      final int NmSplit = 20;
       final int msSplit = 100000;
       final long maxCount = 10000;
       GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -430,7 +430,7 @@ public class PointTest {
       byte[] wktBytes = null;
 
       GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-          geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+          geoJsonPrecision, NmSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
           row -> true, maxAllowedSpeedKnts);
       phase1.process();
 
@@ -456,7 +456,7 @@ public class PointTest {
     for (int simplifierBatchSize = 2; simplifierBatchSize <= 13; simplifierBatchSize++) {
       final int geoJsonPrecision = 5;
       final double simplificationTolerance = 0.000001;
-      final int distanceSplit = 100000;
+      final int NmSplit = 100000;
       final int msSplit = 100000;
       final long maxCount = 10000;
       GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -471,7 +471,7 @@ public class PointTest {
       byte[] wktBytes = null;
 
       GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-          geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+          geoJsonPrecision, NmSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
           row -> true, maxAllowedSpeedKnts);
       phase1.process();
 
@@ -496,7 +496,7 @@ public class PointTest {
   @Test
   public void testLargeFileMultiPrecision() throws Exception {
 
-    final int distanceSplit = 0;
+    final int NmSplit = 0;
     final int msSplit = 0;
     final long maxCount = 10000;
     final long simplifierBatchSize = maxCount;
@@ -517,7 +517,7 @@ public class PointTest {
     byte[] wktBytes = null;
 
     GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-        geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, (int) simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+        geoJsonPrecision, NmSplit, msSplit, geometrySimplifier, (int) simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
         row -> true, maxAllowedSpeedKnts);
     phase1.process();
 
@@ -544,7 +544,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
-    final int distanceSplit = 20;
+    final int NmSplit = 20;
     final int msSplit = 3600000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -559,7 +559,7 @@ public class PointTest {
     byte[] wktBytes = null;
 
     GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-        geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+        geoJsonPrecision, NmSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
         row -> true, maxAllowedSpeedKnts);
     phase1.process();
 
@@ -589,7 +589,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
-    final int distanceSplit = 20;
+    final int NmSplit = 20;
     final int msSplit = 3600000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -604,7 +604,7 @@ public class PointTest {
     byte[] wktBytes = null;
 
     GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-        geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+        geoJsonPrecision, NmSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
         row -> true, maxAllowedSpeedKnts);
     phase1.process();
 
@@ -633,7 +633,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
-    final int distanceSplit = 20;
+    final int NmSplit = 20;
     final int msSplit = 3600000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -648,7 +648,7 @@ public class PointTest {
     byte[] wktBytes = null;
 
     GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-        geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+        geoJsonPrecision, NmSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
         row -> true, maxAllowedSpeedKnts);
     phase1.process();
 
@@ -677,7 +677,7 @@ public class PointTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
-    final int distanceSplit = 20;
+    final int NmSplit = 20;
     final int msSplit = 3600000;
     final long maxCount = 10000;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -692,7 +692,7 @@ public class PointTest {
     byte[] wktBytes = null;
 
     GeoSimplifierProcessor phase1 = new GeoSimplifierProcessor(
-        geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
+        geoJsonPrecision, NmSplit, msSplit, geometrySimplifier, simplifierBatchSize, dataFile, objectMapper, gsf, maxCount, geometryFactory,
         row -> false, maxAllowedSpeedKnts);
     phase1.process();
 

--- a/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/TracklineProcessorTest.java
+++ b/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/TracklineProcessorTest.java
@@ -27,7 +27,7 @@ public class TracklineProcessorTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
-    final int NmSplit = 20;
+    final int NmSplit = 0;
     final int msSplit = 3600000;
     final long maxCount = 0;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -57,7 +57,7 @@ public class TracklineProcessorTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
-    final int NmSplit = 20;
+    final int NmSplit = 0;
     final int msSplit = 3600000;
     final long maxCount = 0;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -87,7 +87,7 @@ public class TracklineProcessorTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
-    final int NmSplit = 20;
+    final int NmSplit = 0;
     final int msSplit = 3600000;
     final long maxCount = 1;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);

--- a/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/TracklineProcessorTest.java
+++ b/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/TracklineProcessorTest.java
@@ -27,7 +27,7 @@ public class TracklineProcessorTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
-    final int distanceSplit = 20;
+    final int NmSplit = 20;
     final int msSplit = 3600000;
     final long maxCount = 0;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -41,7 +41,7 @@ public class TracklineProcessorTest {
     Path dataFile = Paths.get("src/test/resources/phase1/test1/data.txt");
     String gsf = actualDir + "/geoSimplfied.json";
 
-    GeoSimplifierProcessor tracklineProcessor = new GeoSimplifierProcessor(geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize,
+    GeoSimplifierProcessor tracklineProcessor = new GeoSimplifierProcessor(geoJsonPrecision, NmSplit, msSplit, geometrySimplifier, simplifierBatchSize,
         dataFile, objectMapper, Paths.get(gsf), maxCount, geometryFactory, row -> true, maxAllowedSpeedKnts);
 
     tracklineProcessor.process();
@@ -57,7 +57,7 @@ public class TracklineProcessorTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
-    final int distanceSplit = 20;
+    final int NmSplit = 20;
     final int msSplit = 3600000;
     final long maxCount = 0;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -71,7 +71,7 @@ public class TracklineProcessorTest {
     Path dataFile = Paths.get("src/test/resources/phase1/test1/data.txt");
     String gsf = actualDir + "/geoSimplfied.json";
 
-    GeoSimplifierProcessor tracklineProcessor = new GeoSimplifierProcessor(geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize,
+    GeoSimplifierProcessor tracklineProcessor = new GeoSimplifierProcessor(geoJsonPrecision, NmSplit, msSplit, geometrySimplifier, simplifierBatchSize,
         dataFile, objectMapper, Paths.get(gsf), maxCount, geometryFactory, row -> false, maxAllowedSpeedKnts);
 
     tracklineProcessor.process();
@@ -87,7 +87,7 @@ public class TracklineProcessorTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
-    final int distanceSplit = 20;
+    final int NmSplit = 20;
     final int msSplit = 3600000;
     final long maxCount = 1;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -101,7 +101,7 @@ public class TracklineProcessorTest {
     Path dataFile = Paths.get("src/test/resources/phase1/test1/data.txt");
     String gsf = actualDir + "/geoSimplfied.json";
 
-    GeoSimplifierProcessor tracklineProcessor = new GeoSimplifierProcessor(geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize,
+    GeoSimplifierProcessor tracklineProcessor = new GeoSimplifierProcessor(geoJsonPrecision, NmSplit, msSplit, geometrySimplifier, simplifierBatchSize,
         dataFile, objectMapper, Paths.get(gsf), maxCount, geometryFactory, row -> true, maxAllowedSpeedKnts);
 
     SimplifiedPointCountExceededException ex = assertThrows(SimplifiedPointCountExceededException.class, () -> tracklineProcessor.process());

--- a/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/TracklineProcessorTest.java
+++ b/src/test/java/edu/colorado/cires/cmg/tracklinegen/test/TracklineProcessorTest.java
@@ -27,6 +27,7 @@ public class TracklineProcessorTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
+    final int distanceSplit = 20;
     final int msSplit = 3600000;
     final long maxCount = 0;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -40,7 +41,7 @@ public class TracklineProcessorTest {
     Path dataFile = Paths.get("src/test/resources/phase1/test1/data.txt");
     String gsf = actualDir + "/geoSimplfied.json";
 
-    GeoSimplifierProcessor tracklineProcessor = new GeoSimplifierProcessor(geoJsonPrecision, msSplit, geometrySimplifier, simplifierBatchSize,
+    GeoSimplifierProcessor tracklineProcessor = new GeoSimplifierProcessor(geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize,
         dataFile, objectMapper, Paths.get(gsf), maxCount, geometryFactory, row -> true, maxAllowedSpeedKnts);
 
     tracklineProcessor.process();
@@ -56,6 +57,7 @@ public class TracklineProcessorTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
+    final int distanceSplit = 20;
     final int msSplit = 3600000;
     final long maxCount = 0;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -69,7 +71,7 @@ public class TracklineProcessorTest {
     Path dataFile = Paths.get("src/test/resources/phase1/test1/data.txt");
     String gsf = actualDir + "/geoSimplfied.json";
 
-    GeoSimplifierProcessor tracklineProcessor = new GeoSimplifierProcessor(geoJsonPrecision, msSplit, geometrySimplifier, simplifierBatchSize,
+    GeoSimplifierProcessor tracklineProcessor = new GeoSimplifierProcessor(geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize,
         dataFile, objectMapper, Paths.get(gsf), maxCount, geometryFactory, row -> false, maxAllowedSpeedKnts);
 
     tracklineProcessor.process();
@@ -85,6 +87,7 @@ public class TracklineProcessorTest {
     final int geoJsonPrecision = 5;
     final double simplificationTolerance = 0.0001;
     final int simplifierBatchSize = 3000;
+    final int distanceSplit = 20;
     final int msSplit = 3600000;
     final long maxCount = 1;
     GeometrySimplifier geometrySimplifier = new GeometrySimplifier(simplificationTolerance);
@@ -98,7 +101,7 @@ public class TracklineProcessorTest {
     Path dataFile = Paths.get("src/test/resources/phase1/test1/data.txt");
     String gsf = actualDir + "/geoSimplfied.json";
 
-    GeoSimplifierProcessor tracklineProcessor = new GeoSimplifierProcessor(geoJsonPrecision, msSplit, geometrySimplifier, simplifierBatchSize,
+    GeoSimplifierProcessor tracklineProcessor = new GeoSimplifierProcessor(geoJsonPrecision, distanceSplit, msSplit, geometrySimplifier, simplifierBatchSize,
         dataFile, objectMapper, Paths.get(gsf), maxCount, geometryFactory, row -> true, maxAllowedSpeedKnts);
 
     SimplifiedPointCountExceededException ex = assertThrows(SimplifiedPointCountExceededException.class, () -> tracklineProcessor.process());

--- a/src/test/resources/split-null-datetime-just-over-distance.json
+++ b/src/test/resources/split-null-datetime-just-over-distance.json
@@ -1,0 +1,18 @@
+{"type":"Feature","geometry":{"type":"MultiLineString",
+  "coordinates":[
+    [
+      [-157.8803,21.3137],
+      [-157.8904,21.3008]
+    ],[
+      [-157.8919,20.9144],
+      [-157.8919,20.9044]
+    ]
+  ]},
+  "properties": {
+    "distanceM":null,
+    "avgSpeedMPS":null,
+    "unsimplifiedPointCount": 4,
+    "simplifiedPointCount": 4,
+    "targetPointCount": 4
+  }
+}

--- a/src/test/resources/split-null-datetime-just-under-distance.json
+++ b/src/test/resources/split-null-datetime-just-under-distance.json
@@ -1,0 +1,17 @@
+{"type":"Feature","geometry":{"type":"MultiLineString",
+  "coordinates":[
+    [
+      [-157.8803,21.3137],
+      [-157.8904,21.3008],
+      [-157.8919,21.0002],
+      [-157.8919,21.3008]
+    ]
+  ]},
+  "properties": {
+    "distanceM":null,
+    "avgSpeedMPS":null,
+    "unsimplifiedPointCount": 4,
+    "simplifiedPointCount": 4,
+    "targetPointCount": 4
+  }
+}

--- a/src/test/resources/split-null-datetime.json
+++ b/src/test/resources/split-null-datetime.json
@@ -1,0 +1,21 @@
+{"type":"Feature","geometry":{"type":"MultiLineString",
+  "coordinates":[
+    [
+    [-157.8803, 21.3137],
+    [-157.8955, 21.3075],
+    [-157.8904, 21.3008],
+    [-157.8919, 21.2744]
+      ],
+    [
+      [167.3790, -15.3430],
+      [167.5278, -15.2683]
+    ]
+  ]},
+  "properties": {
+    "distanceM":null,
+    "avgSpeedMPS":null,
+    "unsimplifiedPointCount": 6,
+    "simplifiedPointCount": 6,
+    "targetPointCount": 6
+  }
+}


### PR DESCRIPTION
The latest trackline-simplifier release (2.2.7) included changes that allowed input data without timestamps. This functionality builds on that, now also allowing users to specify a distance value by which to split tracklines when there is no timestamp data by which to split tracklines. This will enable cleaner map view-ability for data processed without timestamps. 

The distance value is specified currently in nautical miles.

Existing tests were changed to add NmSplit input, but the value was set to 0 so as to not interfere with existing testing logic. 